### PR TITLE
Why 'icon' class?

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,9 +29,9 @@ Or perhaps you're known to use [bower](http://bower.io/)?
 
 ## HTML Example
 
-You can use [ionicons.com](http://ionicons.com) to easily find the icon you want to use. Once you've copied the desired icon's CSS classname, simply add the `icon` and icon's classname, such as `ion-home` to an HTML element.
+You can use [ionicons.com](http://ionicons.com) to easily find the icon you want to use. Once you've copied the desired icon's CSS classname, such as `ion-home`, simply add it to an HTML element.
 
-    <i class="icon ion-home"></i>
+    <i class="ion-home"></i>
 
 
 ## Build Instructions


### PR DESCRIPTION
There is no reason now to use 'icon' classname (website and demo hasn't it too)
