### PR TITLE
In SCSS files, use @at-root for things that must be root-level declarations

### DIFF
--- a/scss/_ionicons-animation.scss
+++ b/scss/_ionicons-animation.scss
@@ -8,27 +8,28 @@
   animation: spin 1s infinite linear;
 }
 
-@-moz-keyframes spin {
-  0% { -moz-transform: rotate(0deg); }
-  100% { -moz-transform: rotate(359deg); }
+@at-root {
+  @-moz-keyframes spin {
+    0% { -moz-transform: rotate(0deg); }
+    100% { -moz-transform: rotate(359deg); }
+  }
+  @-webkit-keyframes spin {
+    0% { -webkit-transform: rotate(0deg); }
+    100% { -webkit-transform: rotate(359deg); }
+  }
+  @-o-keyframes spin {
+    0% { -o-transform: rotate(0deg); }
+    100% { -o-transform: rotate(359deg); }
+  }
+  @-ms-keyframes spin {
+    0% { -ms-transform: rotate(0deg); }
+    100% { -ms-transform: rotate(359deg); }
+  }
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(359deg); }
+  }
 }
-@-webkit-keyframes spin {
-  0% { -webkit-transform: rotate(0deg); }
-  100% { -webkit-transform: rotate(359deg); }
-}
-@-o-keyframes spin {
-  0% { -o-transform: rotate(0deg); }
-  100% { -o-transform: rotate(359deg); }
-}
-@-ms-keyframes spin {
-  0% { -ms-transform: rotate(0deg); }
-  100% { -ms-transform: rotate(359deg); }
-}
-@keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(359deg); }
-}
-
 
 .#{$ionicons-prefix}loading-a,
 .#{$ionicons-prefix}loading-b,

--- a/scss/_ionicons-font.scss
+++ b/scss/_ionicons-font.scss
@@ -1,15 +1,17 @@
 // Ionicons Font Path
 // --------------------------
 
-@font-face {
- font-family: $ionicons-font-family;
- src:url("#{$ionicons-font-path}/ionicons.eot?v=#{$ionicons-version}");
- src:url("#{$ionicons-font-path}/ionicons.eot?v=#{$ionicons-version}#iefix") format("embedded-opentype"),
-  url("#{$ionicons-font-path}/ionicons.ttf?v=#{$ionicons-version}") format("truetype"),
-  url("#{$ionicons-font-path}/ionicons.woff?v=#{$ionicons-version}") format("woff"),
-  url("#{$ionicons-font-path}/ionicons.svg?v=#{$ionicons-version}#Ionicons") format("svg");
- font-weight: normal;
- font-style: normal;
+@at-root {
+  @font-face {
+   font-family: $ionicons-font-family;
+   src:url("#{$ionicons-font-path}/ionicons.eot?v=#{$ionicons-version}");
+   src:url("#{$ionicons-font-path}/ionicons.eot?v=#{$ionicons-version}#iefix") format("embedded-opentype"),
+    url("#{$ionicons-font-path}/ionicons.ttf?v=#{$ionicons-version}") format("truetype"),
+    url("#{$ionicons-font-path}/ionicons.woff?v=#{$ionicons-version}") format("woff"),
+    url("#{$ionicons-font-path}/ionicons.svg?v=#{$ionicons-version}#Ionicons") format("svg");
+   font-weight: normal;
+   font-style: normal;
+  }
 }
 
 .ion {


### PR DESCRIPTION
In order to nest Ionicons inside a selector, one can do:

``` scss
.foo {
  @import "ionicons/ionicons";
}
```

This ensures that everything is "namespaced" by the selector `.foo` so that Ionicons doesn't leak outside it. However, this breaks SASS (discussed in [this SASS issue](https://github.com/nex3/sass/issues/1251)) because Ionicons declares a `@font-face`, which cannot be nested inside a selector and must be at the root level. The same goes for the keyframe stuff, incidentally.

The fix is to change `_ionicons-font.scss` to use the SASS `@at-root` directive, like so:

``` scss
@at-root {
  @font-face {
   font-family: $ionicons-font-family;
   src:url("#{$ionicons-font-path}/ionicons.eot?v=#{$ionicons-version}");
   src:url("#{$ionicons-font-path}/ionicons.eot?v=#{$ionicons-version}#iefix") format("embedded-opentype"),
    url("#{$ionicons-font-path}/ionicons.ttf?v=#{$ionicons-version}") format("truetype"),
    url("#{$ionicons-font-path}/ionicons.woff?v=#{$ionicons-version}") format("woff"),
    url("#{$ionicons-font-path}/ionicons.svg?v=#{$ionicons-version}#Ionicons") format("svg");
   font-weight: normal;
   font-style: normal;
  }
}
```
