### PR TITLE
get builder working on python 3

### DIFF
--- a/builder/generate.py
+++ b/builder/generate.py
@@ -26,7 +26,7 @@ def main():
 
 
 def generate_font_files():
-  print "Generate Fonts"
+  print("Generate Fonts")
   cmd = "fontforge -script %s/scripts/generate_font.py" % (BUILDER_PATH)
   call(cmd, shell=True)
 
@@ -49,7 +49,7 @@ def rename_svg_glyph_names(data):
 
 
 def generate_less(data):
-  print "Generate LESS"
+  print("Generate LESS")
   font_name = data['name']
   font_version = data['version']
   css_prefix = data['prefix']
@@ -101,7 +101,7 @@ def generate_less(data):
 
 
 def generate_scss(data):
-  print "Generate SCSS"
+  print("Generate SCSS")
   font_name = data['name']
   font_version = data['version']
   css_prefix = data['prefix']
@@ -149,7 +149,7 @@ def generate_scss(data):
 
 
 def generate_css_from_scss(data):
-  print "Generate CSS From SCSS"
+  print("Generate CSS From SCSS")
 
   scss_file_path = os.path.join(SCSS_FOLDER_PATH, 'ionicons.scss')
   css_file_path = os.path.join(CSS_FOLDER_PATH, 'ionicons.css')
@@ -158,13 +158,13 @@ def generate_css_from_scss(data):
   cmd = "sass %s %s --style compact" % (scss_file_path, css_file_path)
   call(cmd, shell=True)
 
-  print "Generate Minified CSS From SCSS"
+  print("Generate Minified CSS From SCSS")
   cmd = "sass %s %s --style compressed" % (scss_file_path, css_min_file_path)
   call(cmd, shell=True)
 
 
 def generate_cheatsheet(data):
-  print "Generate Cheatsheet"
+  print("Generate Cheatsheet")
 
   cheatsheet_file_path = os.path.join(ROOT_PATH, 'cheatsheet.html')
   template_path = os.path.join(BUILDER_PATH, 'cheatsheet', 'template.html')
@@ -205,7 +205,7 @@ def generate_cheatsheet(data):
 
 
 def generate_component_json(data):
-  print "Generate component.json"
+  print("Generate component.json")
   d = {
     "name": data['name'],
     "repo": "driftyco/ionicons",
@@ -234,7 +234,7 @@ def generate_component_json(data):
 
 
 def generate_composer_json(data):
-  print "Generate composer.json"
+  print("Generate composer.json")
   d = {
     "name": "driftyco/ionicons",
     "description": "The premium icon font for Ionic Framework.",
@@ -272,7 +272,7 @@ def generate_composer_json(data):
 
 
 def generate_bower_json(data):
-  print "Generate bower.json"
+  print("Generate bower.json")
   d = {
     "name": data['name'],
     "version": data['version'],

--- a/builder/scripts/eotlitetool.py
+++ b/builder/scripts/eotlitetool.py
@@ -453,7 +453,7 @@ def main():
     for f in args:
         data = readfont(f)
         if len(data) == 0:
-            print 'Error reading %s' % f
+            print('Error reading %s' % f)
         else:
             eot = eotname(f)
             header = make_eot_header(data)

--- a/builder/scripts/generate_font.py
+++ b/builder/scripts/generate_font.py
@@ -31,7 +31,7 @@ f.descent = 64
 manifest_file = open(MANIFEST_PATH, 'r')
 manifest_data = json.loads(manifest_file.read())
 manifest_file.close()
-print "Load Manifest, Icons: %s" % ( len(manifest_data['icons']) )
+print("Load Manifest, Icons: %s" % ( len(manifest_data['icons']) ))
 
 build_data = copy.deepcopy(manifest_data)
 build_data['icons'] = []
@@ -57,7 +57,7 @@ for dirname, dirnames, filenames in os.walk(INPUT_SVG_DIR):
 
       if chr_code is None:
         # this is a new src icon
-        print 'New Icon: \n - %s' % (name)
+        print('New Icon: \n - %s' % (name))
 
         while True:
           chr_code = '0x%x' % (cp)
@@ -71,7 +71,7 @@ for dirname, dirnames, filenames in os.walk(INPUT_SVG_DIR):
           if not already_exists:
             break
 
-        print ' - %s' % chr_code
+        print(' - %s' % chr_code)
         manifest_data['icons'].append({
           'name': name,
           'code': chr_code
@@ -123,7 +123,7 @@ for dirname, dirnames, filenames in os.walk(INPUT_SVG_DIR):
 build_hash = m.hexdigest()
 
 if build_hash == manifest_data.get('build_hash'):
-  print "Source files unchanged, did not rebuild fonts"
+  print("Source files unchanged, did not rebuild fonts")
 
 else:
   manifest_data['build_hash'] = build_hash
@@ -161,12 +161,12 @@ else:
   manifest_data['icons'] = sorted(manifest_data['icons'], key=lambda k: k['name'])
   build_data['icons'] = sorted(build_data['icons'], key=lambda k: k['name'])
 
-  print "Save Manifest, Icons: %s" % ( len(manifest_data['icons']) )
+  print("Save Manifest, Icons: %s" % ( len(manifest_data['icons']) ))
   f = open(MANIFEST_PATH, 'w')
   f.write( json.dumps(manifest_data, indent=2, separators=(',', ': ')) )
   f.close()
 
-  print "Save Build, Icons: %s" % ( len(build_data['icons']) )
+  print("Save Build, Icons: %s" % ( len(build_data['icons']) ))
   f = open(BUILD_DATA_PATH, 'w')
   f.write( json.dumps(build_data, indent=2, separators=(',', ': ')) )
   f.close()


### PR DESCRIPTION
Hey folks,

 I just noticed that the builder scripts were incompatible with Python 3. These simple changes make them work on Python 3 while remaining backward compatible with Python 2. Also, as of Python 3.6 dictionaries will retain insertion order so the JSON files should always come out exactly as they are specified in `generate.py`