### PR TITLE
Fix logo icon type snippets

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,8 @@ Many icons have both Material Design and iOS versions to provide Platform Contin
 
 Platform Continuity means that by default, ionicons running on iOS (Apple products such as iPhone and iPad) will display `ios` styled icons. Alternatively, ionicons running on devices with Material Design theme (commonly seen on Android devices) will see the `md` styled icons.
 
+Note: this typically does not apply to logo type icons; they do not have platform specific versions.
+
 ### Platform Continuity Within Ionic Apps
 
 Ionic will automatically use the correct version based on the platform. Note that this feature will only automatically kick-in for Ionic apps. When being used outside of an Ionic app, please see the "Outside Ionic App" section below.

--- a/src/docs/site/components/toast-bar/toast-bar.tsx
+++ b/src/docs/site/components/toast-bar/toast-bar.tsx
@@ -26,7 +26,7 @@ export class ToastBar {
     const codeElParent = this.el.querySelector('.toast-bar__section:first-child');
     const el = document.createElement('textarea');
 
-    el.value = `<ion-icon name="${ this.selectedIcon.name }"></ion-icon>`;
+    el.value = `<ion-icon name="${ this.snippetIconName() }"></ion-icon>`;
     el.setAttribute('readonly', '');
     el.style.position = 'absolute';
     el.style.left = '-9999px';
@@ -44,6 +44,14 @@ export class ToastBar {
       codeElParent.classList.remove('copied');
       this.showCopiedConfirm = 0;
     }, 1500);
+  }
+
+  isLogoType() {
+    return this.selectedIcon && this.selectedIcon.icons[0].startsWith('logo-');
+  }
+
+  snippetIconName() {
+    return (this.isLogoType() ? 'logo-' : '') + this.selectedIcon.name;
   }
 
   componentDidLoad () {
@@ -69,6 +77,7 @@ export class ToastBar {
   }
 
   render() {
+    let snippetIconName;
     let snippetLength;
     let iconType;
     let activeDownloadLinks = null;
@@ -76,9 +85,10 @@ export class ToastBar {
     if (this.selectedIcon) {
       if (!this.hadIconOnce) this.hadIconOnce = true;
 
-      iconType = this.selectedIcon.icons[0].startsWith('logo-') ? 'logo' : this.selectedIconType;
+      iconType = this.isLogoType() ? 'logo' : this.selectedIconType;
 
-      snippetLength = (`<ion-icon name="${ this.selectedIcon.name }"></ion-icon>`.length * 8) + 32;
+      snippetIconName = this.snippetIconName();
+      snippetLength = (`<ion-icon name="${ snippetIconName }"></ion-icon>`.length * 8) + 32;
 
       activeDownloadLinks = this.selectedIcon.icons.map((name) => {
         const type = name.substr(0, name.indexOf('-'));
@@ -140,7 +150,7 @@ export class ToastBar {
 
                   <code>
                     <span class="hover-highlight" onClick={() => this.handleCodeClick()}>
-                      {'<'}<span class="yellow">ion-icon</span>&nbsp;<span class="orange">name</span>{'='}<span class="green">{`"${this.selectedIcon.name}"`}</span>{'>'}{'</'}<span class="yellow">ion-icon</span>{'>'}
+                      {'<'}<span class="yellow">ion-icon</span>&nbsp;<span class="orange">name</span>{'='}<span class="green">{`"${snippetIconName}"`}</span>{'>'}{'</'}<span class="yellow">ion-icon</span>{'>'}
                     </span>
                   </code>
 

--- a/src/docs/site/components/usage-page/content.tsx
+++ b/src/docs/site/components/usage-page/content.tsx
@@ -1,6 +1,8 @@
 import hljs from 'highlight.js';
 
 export default function (version: string, type = "md", name = "heart") {
+  const snippetIconName = (type === "logo" ? "logo-" : "") + name;
+
   return (<div>
 
 <h1>Usage</h1>
@@ -21,7 +23,7 @@ export default function (version: string, type = "md", name = "heart") {
 <h3 id="basic-usage">Basic usage</h3>
 <p>To use a built-in icon from the Ionicons package, populate the <code>name</code> attribute on the <code>ion-icon</code> component:</p>
 {highlight(
-`<ion-icon name="${name}"></ion-icon>`
+`<ion-icon name="${snippetIconName}"></ion-icon>`
 )}
 
 <p>To use a custom SVG, provide its url in the <code>src</code> attribute to request the external SVG file. The <code>src</code> attribute works the same as <code>&lt;img src="..."&gt;</code> in that the url must be accessible from the webpage that's making a request for the image. Additionally, the external file can only be a valid <code>svg</code> and does not allow scripts or events within the <code>svg</code> element.</p>
@@ -49,11 +51,15 @@ export default function (version: string, type = "md", name = "heart") {
 <h3>Platform Continuity Outside Ionic Apps</h3>
 
 <p>When using Ionicons without the <a href="https://ionicframework.com/">Ionic Framework</a>, the icon will default to the Material Design icon style. To specify the non-default icon style, add a platform prefix to the <code>name</code> attribute.</p>
-{highlight(
-`<ion-icon name="ios-${name}"></ion-icon>`
+{(type == 'logo') ? highlight(
+    `<ion-icon name="ios-heart"></ion-icon>`
+):highlight(
+    `<ion-icon name="ios-${name}"></ion-icon>`
 )}
-{highlight(
-`<ion-icon name="md-${name}"></ion-icon>`
+{(type == 'logo') ? highlight(
+    `<ion-icon name="md-heart"></ion-icon>`
+):highlight(
+    `<ion-icon name="md-${name}"></ion-icon>`
 )}
 
 <h3>Icon sizes</h3>

--- a/src/docs/site/components/usage-page/content.tsx
+++ b/src/docs/site/components/usage-page/content.tsx
@@ -2,6 +2,7 @@ import hljs from 'highlight.js';
 
 export default function (version: string, type = "md", name = "heart") {
   const snippetIconName = (type === "logo" ? "logo-" : "") + name;
+  const snippedPlatformSpecificIconName = type === "logo" ? "heart" : name;
 
   return (<div>
 
@@ -42,24 +43,18 @@ export default function (version: string, type = "md", name = "heart") {
 <p>Ionic will automatically use the correct version based on the platform. Note that this feature will only automatically kick-in for Ionic apps. When being used outside of an Ionic app, please see the "Outside Ionic App" section below.</p>
 
 <p>To specify the icon for each platform, use the <code>md</code> and <code>ios</code> attributes and provide the platform specific icon name.</p>
-{(type == 'logo') ? highlight(
-`<ion-icon ios="ios-heart" md="md-heart"></ion-icon>`
-):highlight(
-`<ion-icon ios="ios-${name}" md="md-${name}"></ion-icon>`
+{highlight(
+`<ion-icon ios="ios-${snippedPlatformSpecificIconName}" md="md-${snippedPlatformSpecificIconName}"></ion-icon>`
 )}
 
 <h3>Platform Continuity Outside Ionic Apps</h3>
 
 <p>When using Ionicons without the <a href="https://ionicframework.com/">Ionic Framework</a>, the icon will default to the Material Design icon style. To specify the non-default icon style, add a platform prefix to the <code>name</code> attribute.</p>
-{(type == 'logo') ? highlight(
-    `<ion-icon name="ios-heart"></ion-icon>`
-):highlight(
-    `<ion-icon name="ios-${name}"></ion-icon>`
+{highlight(
+`<ion-icon name="ios-${snippedPlatformSpecificIconName}"></ion-icon>`
 )}
-{(type == 'logo') ? highlight(
-    `<ion-icon name="md-heart"></ion-icon>`
-):highlight(
-    `<ion-icon name="md-${name}"></ion-icon>`
+{highlight(
+`<ion-icon name="md-${snippedPlatformSpecificIconName}"></ion-icon>`
 )}
 
 <h3>Icon sizes</h3>

--- a/src/docs/site/components/usage-page/content.tsx
+++ b/src/docs/site/components/usage-page/content.tsx
@@ -37,6 +37,8 @@ export default function (version: string, type = "md", name = "heart") {
 
 <p>Platform Continuity means that by default, ionicons running on iOS (Apple products such as iPhone and iPad) will display <code>ios</code> styled icons. Alternatively, ionicons running on devices with Material Design theme (commonly seen on Android devices) will see the <code>md</code> styled icons.</p>
 
+<p>Note: this typically does not apply to logo type icons; they do not have platform specific versions.</p>
+
 
 <h3>Platform Continuity Within Ionic Apps</h3>
 


### PR DESCRIPTION
Hi,

This PR tweaks the icon name if it is a logo type for code snippets in ToastBar and UsagePage's Content.
However, in UsagePage it defaults to `"heart"` value for "Platform specific icons" section, because it does not apply to logo type icons (you cannot use `ios` and `md` attributes with a logo value, and you cannot specify `"ios-logo-github"` or `"md-logo-github"` to the `name` attribute).

A minor inconsistency remains in the ToastBar: the left title still displays the icon name, which _does not_ include the `logo-` prefix.
Since this title is very big, and for other icon types it is equal to the value you can pass to the `name` attribute, this might still create confusion when developer realizes it is not the case for logo type icons.
But at least with this PR code snippets are now correct.

Fix #540