### PR TITLE
Fix Cheatsheet Link

### DIFF
--- a/src/docs/site/components/footer-bar/footer-bar.tsx
+++ b/src/docs/site/components/footer-bar/footer-bar.tsx
@@ -23,7 +23,7 @@ export class FooterBar {
         </div>
 
         <div class="footer-menu">
-          <a href="cheatsheet.html">Cheatsheet</a>
+          <a href="/cheatsheet.html">Cheatsheet</a>
           <a href="/v1">v1</a>
           <a href="/v2">v2</a>
           <a href="https://ionicframework.com/docs/ionicons/">v3</a>


### PR DESCRIPTION
When on the "Usage" page, selecting the "Cheatsheet" link will result in a 404 since it takes the browser to:
https://ionicons.com/usage/cheatsheet.html
instead of:
https://ionicons.com/cheatsheet.html