### PR TITLE
chore(deps) update to latest stencil and others

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,23 +27,23 @@
     "test": "stencil test --spec"
   },
   "devDependencies": {
-    "@stencil/core": "0.13.0",
+    "@stencil/core": "0.13.2",
     "@stencil/router": "0.3.0",
-    "@stencil/sass": "0.0.5",
+    "@stencil/sass": "0.1.1",
     "@types/highlight.js": "^9.12.3",
-    "@types/jest": "^23.1.3",
-    "@types/puppeteer": "1.6.4",
-    "archiver": "^2.1.1",
-    "fs-extra": "4.0.2",
+    "@types/jest": "^23.3.3",
+    "@types/puppeteer": "1.9.0",
+    "archiver": "^3.0.0",
+    "fs-extra": "7.0.0",
     "highlight.js": "^9.12.0",
     "jest": "23.5.0",
-    "node-sass": "4.9.0",
+    "node-sass": "4.9.3",
     "np": "3.0.4",
     "pixelmatch": "4.0.2",
-    "puppeteer": "1.7.0",
-    "svgo": "1.0.5",
+    "puppeteer": "1.9.0",
+    "svgo": "1.1.1",
     "tslint": "^5.11.0",
-    "tslint-ionic-rules": "0.0.17"
+    "tslint-ionic-rules": "0.0.19"
   },
   "keywords": [
     "ionicons",


### PR DESCRIPTION
Relates to https://github.com/ionic-team/ionicons/issues/621

Security errors down from 27 to 17

All current tests still pass

![capture414](https://user-images.githubusercontent.com/140737/46594742-c63cbe00-ca89-11e8-85ff-ba99d736b9ef.png)

![capture415](https://user-images.githubusercontent.com/140737/46594755-e0769c00-ca89-11e8-8af1-7d36bff69f6d.png)
