### PR TITLE
fix: remove unused size custom properties

### DIFF
--- a/src/components/icon/icon.css
+++ b/src/components/icon/icon.css
@@ -14,11 +14,11 @@
 }
 
 :host(.icon-small) {
-  font-size: var(--ion-icon-size-small, 18px) !important;
+  font-size: 18px !important;
 }
 
 :host(.icon-large){
-  font-size: var(--ion-icon-size-large, 32px) !important;
+  font-size: 32px !important;
 }
 
 .icon-inner,


### PR DESCRIPTION
This removes the use of two undocumented custom properties from the component styles.

- `--ion-icon-size-large`
- `--ion-icon-size-small`