### PR TITLE
fix: default export a function in global script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "scripts": {
-    "build": "npm run lint.ts && npm run build.icon && npm run generate && npm run build.css && npm run copy.tasks && npm run test && npm run build.data",
+    "build": "npm run lint.ts && npm run build.data && npm run build.icon && npm run generate && npm run build.css && npm run copy.tasks && npm run test",
     "build.css": "node scripts/build-css.js",
     "build.data": "node scripts/data.js",
     "build.icon": "stencil build",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test": "stencil test --spec"
   },
   "devDependencies": {
-    "@stencil/core": "1.1.6",
+    "@stencil/core": "1.3.0",
     "@stencil/sass": "^1.0.1",
     "@types/highlight.js": "^9.12.3",
     "@types/jest": "24.0.13",

--- a/src/components/global.ts
+++ b/src/components/global.ts
@@ -1,3 +1,5 @@
 import { setMode } from '@stencil/core';
 
-setMode((el: any) => el.tagName === 'ION-ICON' ? el.mode || el.getAttribute('mode') : null);
+export default () => {
+  setMode((el: any) => el.tagName === 'ION-ICON' ? el.mode || el.getAttribute('mode') : null);
+}

--- a/src/components/global.ts
+++ b/src/components/global.ts
@@ -2,4 +2,4 @@ import { setMode } from '@stencil/core';
 
 export default () => {
   setMode((el: any) => el.tagName === 'ION-ICON' ? el.mode || el.getAttribute('mode') : null);
-}
+};


### PR DESCRIPTION
Currently, the `ionic-pwa-toolkit` starter fails to build (at least with `@stencil/core@1.3.0` but I think already before that) because of the `ionicons` dependency:

```
[ ERROR ]  Global Script: node_modules/ionicons/dist/collection/global.js
           The code to be executed should be placed within a default function that is exported by the global script.
           Ensure all of the code in the global script is wrapped in the function() that is exported.
```

To fix that, this PR:

- bumps Stencil to 1.3.0
- wraps the global script code in a function that is default exported
- fixes the build script order

For the last point, please check whether that's ok. The reason is that I wasn't able to build the project because the `icons` folder was missing until the `build.data` script had been run (which generates that `icons` folder. Might be related to 883934186022812214c5ba584cad31dbe209ab00.

---

To make the pwa-toolkit starter work again, the following actions have to be taken:

- merge this PR and make a release
- update the `ionicons` dependency in the `@ionic/core` package
- release a new `@ionic/core` version
- update the `@ionic/core` dependency in `ionic-pwa-toolkit`
