### PR TITLE
Added font-display property and ionicons-font-display variable

### DIFF
--- a/src/scss/ionicons-variables.scss
+++ b/src/scss/ionicons-variables.scss
@@ -2,6 +2,7 @@
 // Ionicons Variables
 // --------------------------
 
+$ionicons-font-display: "swap" !default;
 $ionicons-font-path: "../fonts" !default;
 $ionicons-font-family: "Ionicons" !default;
 $ionicons-version: "4.0.0-0" !default;

--- a/src/scss/ionicons.scss
+++ b/src/scss/ionicons.scss
@@ -24,6 +24,7 @@
   url("#{$ionicons-font-path}/ionicons.svg?v=#{$ionicons-version}#Ionicons") format("svg");
  font-weight: normal;
  font-style: normal;
+ font-display: $ionicons-font-display;
 }
 
 .ion {


### PR DESCRIPTION
Added font-display property and variable for it's configuration.
This fixes following issue https://github.com/ionic-team/ionicons/issues/697 and issue where Chrome's Audit critical warning "Ensure text remains visible during  webfont load".