### PR TITLE
Add window check to icon

### DIFF
--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -5,7 +5,7 @@ import { Icon } from './icon';
 let CACHED_MAP: Map<string, string>;
 
 export const getIconMap = (): Map<string, string> => {
-  if (!CACHED_MAP) {
+  if (!CACHED_MAP && typeof window !== 'undefined') {
     const win = window as any;
     win.Ionicons = win.Ionicons || {};
     CACHED_MAP = win.Ionicons.map = win.Ionicons.map || new Map();


### PR DESCRIPTION
I was playing with ssr and `window is undefined` was popping up from ionicons. After searching through the repo, I believe this is the only place where it is not guarded.