### PR TITLE
fix(icon): apply correct class to svg

### DIFF
--- a/src/components/icon/icon.css
+++ b/src/components/icon/icon.css
@@ -25,7 +25,8 @@
 }
 
 .icon-inner,
-.ionicon {
+.ionicon,
+svg {
   display: block;
 
   height: 100%;

--- a/src/components/icon/validate.ts
+++ b/src/components/icon/validate.ts
@@ -17,7 +17,7 @@ export const validateContent = (svgContent: string | null) => {
     const svgElm = div.firstElementChild;
     if (svgElm && svgElm.nodeName.toLowerCase() === 'svg') {
       const svgClass = svgElm.getAttribute('class') || '';
-      svgElm.setAttribute('class', (svgClass + ' s-ion-icon').trim());
+      svgElm.setAttribute('class', (svgClass + ' s-ion-icon ionicon').trim());
 
       // root element must be an svg
       // lets double check we've got valid elements

--- a/src/components/icon/validate.ts
+++ b/src/components/icon/validate.ts
@@ -17,7 +17,7 @@ export const validateContent = (svgContent: string | null) => {
     const svgElm = div.firstElementChild;
     if (svgElm && svgElm.nodeName.toLowerCase() === 'svg') {
       const svgClass = svgElm.getAttribute('class') || '';
-      svgElm.setAttribute('class', (svgClass + ' s-ion-icon ionicon').trim());
+      svgElm.setAttribute('class', (svgClass + ' s-ion-icon').trim());
 
       // root element must be an svg
       // lets double check we've got valid elements

--- a/src/index.html
+++ b/src/index.html
@@ -46,6 +46,10 @@
   <h2>Stroke width</h2>
   <ion-icon name="heart-outline" style="--ionicon-stroke-width: 8px;"></ion-icon>
 
+  <h2>Font size</h2>
+  <ion-icon name="book" style="font-size: 50px;"></ion-icon>
+  <ion-icon src="./assets/bug_report.svg" style="font-size: 50px;"></ion-icon>
+
   <h2>Custom SVGs</h2>
   <ion-icon src="./assets/bug_report.svg"></ion-icon>
   <ion-icon src="./assets/chat.svg"></ion-icon>


### PR DESCRIPTION
This PR fixes a regression in ionicons v5 where the inner SVG content of an ion-icon with a custom `src` does not get the proper styles applied due to a missing class. This results in a regression where setting the `font-size` on an `ion-icon` does not apply to ion-icons with a custom `src`.

In v4, we targeted the `svg` to apply proper styles. v5 targets `.ionicon` instead. Unfortunately, we only apply that class to the stock icons at build time, not to the custom icons that are loaded.

Example:

```
<ion-icon name="book" style="font-size: 50px;"></ion-icon>
<ion-icon src="./assets/bug_report.svg" style="font-size: 50px;"></ion-icon>
```

Expected Result: I would expect that the custom and standard icons are relatively the same size (around 50px)
Actual Result: The book icon grows in size, but the custom icon stays the same.

Other Info: The "Expected Result" is the behavior in the `4.x` branch.