### PR TITLE
fix(icon): include chevron icons in flipRtl

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -142,7 +142,7 @@ export class Icon {
 
   render() {
     const mode = this.mode || 'md';
-    const flipRtl = this.flipRtl || (this.ariaLabel && this.ariaLabel.indexOf('arrow') > -1 && this.flipRtl !== false);
+    const flipRtl = this.flipRtl || (this.ariaLabel && (this.ariaLabel.indexOf('arrow') > -1 || this.ariaLabel.indexOf('chevron') > -1) && this.flipRtl !== false);
 
     return (
       <Host role="img" class={{

--- a/src/index.html
+++ b/src/index.html
@@ -105,6 +105,18 @@
   <ion-icon name="arrow-down" flip-rtl="false"></ion-icon>
   <ion-icon name="arrow-back" flip-rtl="false"></ion-icon>
 
+  <h2>Auto Flip: chevrons</h2>
+  <ion-icon name="chevron-up"></ion-icon>
+  <ion-icon name="chevron-forward"></ion-icon>
+  <ion-icon name="chevron-down"></ion-icon>
+  <ion-icon name="chevron-back"></ion-icon>
+
+  <h2>Un-flip: chevrons</h2>
+  <ion-icon name="chevron-up" flip-rtl="false"></ion-icon>
+  <ion-icon name="chevron-forward" flip-rtl="false"></ion-icon>
+  <ion-icon name="chevron-down" flip-rtl="false"></ion-icon>
+  <ion-icon name="chevron-back" flip-rtl="false"></ion-icon>
+
   <p>
     <a href="./cheatsheet.html">Cheatsheet</a>
   </p>


### PR DESCRIPTION
The new chevron icons are not included in the logic needed to apply RTL.

Expected:
`chevron-forward-circle` points to the right on LTR and to the left on RTL.

Actual:
`chevron-forward-circle` points to the right on both LTR and RTL.