### PR TITLE
use cloudfare cdn instead of unpkg

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ Also note that only visible icons are loaded, and icons which are "below the fol
 If you're using [Ionic Framework](https://ionicframework.com/), Ionicons is packaged by default, so no installation is necessary. Want to use Ionicons without Ionic Framework? Place the following `<script>` near the end of your page, right before the closing </body> tag, to enable them.
 
 ```html
-<script src="https://unpkg.com/ionicons@5.0.0/dist/ionicons.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/ionicons/5.0.0/ionicons.js"></script>
 ```
 
 ### Basic usage


### PR DESCRIPTION
this PR comes after this issue on stackoverflow: https://stackoverflow.com/questions/58652885/how-do-i-fix-cors-issue-when-using-ionicons-from-cdn/60263752#60263752

which's I faced myself on my company, it turns now unpkg injects redirects on their CDN makes the browser detect cross-origin errors and block loading the files.

so I recommend use cloudfare instead.