### PR TITLE
fix multiple people icon update name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ The table below outlines icons that were removed or renamed.
 | chatboxes                    | :pencil2:   | renamed     | renamed to "chatbox"                                                  |
 | clock                        | :x:         | deleted     |                                                                       |
 | contact                      | :pencil2:   | renamed     | renamed to "person-circle"                                            |
-| contacts                     | :pencil2:   | renamed     | renamed to "person-circle"                                            |
+| contacts                     | :pencil2:   | renamed     | renamed to "people-circle"                                            |
 | done-all                     | :pencil2:   | renamed     | renamed to "checkmark-done"                                           |
 | fastforward	                 | :pencil2:   | renamed     | renamed to "play-forward"                                             |
 | filing                       | :pencil2:   | renamed     | renamed to "file-tray"                                                |


### PR DESCRIPTION
The v4 icon that showed multiple generic figures was called "contacts". The updated v5 analog would be "people" or "people-circle" (https://ionicons.com/usage#people-circle-outline). However the upgrade doc (https://github.com/ionic-team/ionicons/blob/master/CHANGELOG.md) incorrectly identifies  "person" - the singular figure icon - as the updated version of "contacts". This simple change corrects that.