### PR TITLE
fix: ariaHidden documentation source

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -7,6 +7,9 @@
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
     interface IonIcon {
+        /**
+          * Set the icon to hidden, respectively `true`, to remove it from the accessibility tree.
+         */
         "ariaHidden"?: string;
         /**
           * Specifies the label to use for accessibility. Defaults to the icon name.
@@ -67,6 +70,9 @@ declare global {
 }
 declare namespace LocalJSX {
     interface IonIcon {
+        /**
+          * Set the icon to hidden, respectively `true`, to remove it from the accessibility tree.
+         */
         "ariaHidden"?: string;
         /**
           * Specifies the label to use for accessibility. Defaults to the icon name.

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -32,6 +32,9 @@ export class Icon {
    */
   @Prop({ mutable: true, reflectToAttr: true }) ariaLabel?: string;
 
+  /**
+   * Set the icon to hidden, respectively `true`, to remove it from the accessibility tree.
+   */
   @Prop({reflect: true}) ariaHidden?: string;
 
   /**


### PR DESCRIPTION
Follow-up [#869](https://github.com/ionic-team/ionicons/pull/869). In previous PR I added the doc "manually" to the readme.md instead of writing it down in the component.