### PR TITLE
chore: add tag "globe" to earth

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -3666,13 +3666,15 @@
     {
       "name": "earth",
       "tags": [
-        "earth"
+        "earth",
+        "globe"
       ]
     },
     {
       "name": "earth-outline",
       "tags": [
         "earth",
+        "globe",
         "outline"
       ]
     },
@@ -3680,6 +3682,7 @@
       "name": "earth-sharp",
       "tags": [
         "earth",
+        "globe",
         "sharp"
       ]
     },


### PR DESCRIPTION
In Ionicons v4 the Earth icon was called globe. So it makes sense to add this as a tag.