### PR TITLE
fix(): adding aria-hidden no longer disables automatic rtl switching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -894,9 +894,9 @@
       }
     },
     "@stencil/core": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.4.0.tgz",
-      "integrity": "sha512-gU6+Yyd6O0KrCSS/O6j8KKqmRo+/Dcs2fI0+APCpbAWK+nqhwDISpdnSEfGDCLMoAC08XOZCycBRk2K1VGnEcg=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-gpoYJEYzu5LV2hr7uPZklug3zXhEbYGKyNodPfmOOYZtO9q42l7RQ3cAnC8MzEoF4jFrfemgtevGik8sqn9ClQ=="
     },
     "@szmarczak/http-timer": {
       "version": "4.0.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "version": "npm run build"
   },
   "dependencies": {
-    "@stencil/core": "^2.4.0"
+    "@stencil/core": "^2.5.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^9.0.6",

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -10,6 +10,7 @@ import { getName, getUrl } from './utils';
 })
 export class Icon {
   private io?: IntersectionObserver;
+  private iconName: string | null = null;
 
   @Element() el!: HTMLElement;
 
@@ -143,8 +144,9 @@ export class Icon {
       }
     }
 
+    const label = this.iconName = getName(this.name, this.icon, this.mode, this.ios, this.md);
+
     if (!this.ariaLabel && this.ariaHidden !== 'true') {
-      const label = getName(this.name, this.icon, this.mode, this.ios, this.md);
       // user did not provide a label
       // come up with the label based on the icon name
       if (label) {
@@ -154,11 +156,12 @@ export class Icon {
   }
 
   render() {
+    const { iconName } = this;
     const mode = this.mode || 'md';
     const flipRtl =
       this.flipRtl ||
-      (this.ariaLabel &&
-        (this.ariaLabel.indexOf('arrow') > -1 || this.ariaLabel.indexOf('chevron') > -1) &&
+      (iconName &&
+        (iconName.indexOf('arrow') > -1 || iconName.indexOf('chevron') > -1) &&
         this.flipRtl !== false);
 
     return (

--- a/src/components/icon/test/icon.spec.ts
+++ b/src/components/icon/test/icon.spec.ts
@@ -29,4 +29,20 @@ describe('icon', () => {
       </ion-icon>
     `);
   });
+
+  it('renders rtl with aria-hidden', async () => {
+    const { root } = await newSpecPage({
+      components: [Icon],
+      direction: 'rtl',
+      html: `<ion-icon name="chevron-forward" aria-hidden="true"></ion-icon>`,
+    });
+
+    expect(root).toEqualHtml(`
+      <ion-icon class="md flip-rtl" name="chevron-forward" role="img" aria-hidden="true">
+        <mock:shadow-root>
+          <div class="icon-inner"></div>
+        </mock:shadow-root>
+      </ion-icon>
+    `);
+  });
 });


### PR DESCRIPTION
See also: https://github.com/ionic-team/ionic-framework/issues/23078

This PR fixes an issue where setting `aria-hidden="true"` would cause `flipRtl` to always equal `false` unless `this.flipRtl` was explicitly set. 

The reason this happened was `aria-hidden="true"` caused the component to not automatically generate an `aria-label`. We used this label to determine whether or not we should automatically flip the icon according to RTL mode. 

To fix this, I created a private variable that holds the icon name. We reference this icon to determine the state of `flipRtl`, and we also use this variable when auto generating an `aria-label`.