### PR TITLE
fix(build): add old ionicons.js file 

### DIFF
--- a/scripts/collection-copy.ts
+++ b/scripts/collection-copy.ts
@@ -26,6 +26,18 @@ async function collectionCopy(rootDir: string) {
     private: true,
   };
   await fs.writeFile(cePackageJsonPath, JSON.stringify(cePackageJson, null, 2));
+  
+  /**
+   * TODO: Remove this in Ionicons v6.0
+   * Stencil 2 removed the legacy loader,
+   * but that is what Ionicons users were using
+   * to load Ionicons from a CDN. The lines
+   * below will add in a legacy loader for users
+   * to use so there is no breaking change in usage.
+   */
+  const installLoaderSrc = join(rootDir, 'scripts', 'install-loader.js');
+  const installLoaderDest = join(rootDir, 'dist', 'ionicons.js');
+  await fs.copyFile(installLoaderSrc, installLoaderDest)
 
   // this is temporary!!!!
   // removing the `type` from the d.ts export

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -2,6 +2,7 @@ import { Config } from '@stencil/core';
 
 export const config: Config = {
   namespace: 'ionicons',
+  buildEs5: 'prod',
   outputTargets: [
     {
       type: 'dist',


### PR DESCRIPTION
Stencil 1 had a deprecated loader that, when used, automatically added `module` and `nomodule` script tags to your web page. In Stencil 2 that loader was removed in favor of adding the `module` and `nomodule` script tags manually.

Ionicons v5.5 updated its internals to Stencil 2 to better support the custom elements bundle functionality, but in doing so we lost the deprecated loader.

This PR re-adds the deprecated loader, but it will be removed in Ionicons v6.0.

I will also be updating the Ionicons docs website with the new usage that Stencil 2 recommends.