### PR TITLE
feat(icon): expose 'icon-inner' and 'svg' as shadow parts

### DIFF
--- a/src/components/icon/readme.md
+++ b/src/components/icon/readme.md
@@ -22,6 +22,14 @@
 | `src`      | `src`      | Specifies the exact `src` of an SVG file to use.                                                                                                                                              | `string \| undefined`  | `undefined`    |
 
 
+## Shadow Parts
+
+| Part           | Description |
+| -------------- | ----------- |
+| `"icon-inner"` | The container that wraps the SVG element |
+| `"svg"` | The svg element |
+
+
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/src/index.html
+++ b/src/index.html
@@ -130,6 +130,10 @@
     <h2>Not Sanitized (should show)</h2>
     <ion-icon sanitize="false" src="./assets/no-sanitize.svg"></ion-icon>
 
+    <h2>Accessing ::part()'s</h2>
+    <ion-icon id="part-svg" src="./assets/bug_report.svg"></ion-icon>
+    <ion-icon id="part-icon-inner" src="./assets/chat.svg"></ion-icon>
+
     <p>
       <a href="./cheatsheet.html">Cheatsheet</a>
     </p>
@@ -155,6 +159,14 @@
       .custom {
         stroke: red;
         fill: blue;
+      }
+
+      #part-svg::part(svg) {
+        fill: rebeccapurple;
+      }
+
+      #part-icon-inner::part(icon-inner) {
+        fill: aliceblue;
       }
     </style>
   </body>


### PR DESCRIPTION
For #960 

- expose ``.icon-inner`` and the SVG element as shadow parts ```::part(icon-inner)`` & ``::part(svg)``
- add `examples to ``index.html``
- update ``icon/readme.md``

(To be honest: this feels kind of hacky to me, so i opened this for discussion. Sorry for the inconvenience - if it causes any.)