### PR TITLE
Add tags to options icon

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -7419,13 +7419,17 @@
     {
       "name": "options",
       "tags": [
-        "options"
+        "options",
+        "sliders",
+        "filters"
       ]
     },
     {
       "name": "options-outline",
       "tags": [
         "options",
+        "sliders",
+        "filters",
         "outline"
       ]
     },
@@ -7433,6 +7437,8 @@
       "name": "options-sharp",
       "tags": [
         "options",
+        "sliders",
+        "filters",
         "sharp"
       ]
     },


### PR DESCRIPTION
I've added a couple new tags to the options icon to make it easier to find. 

Sliders, because the icon itself does look like range sliders and a user looking not knowing what it's called could just be describing what it looks like hoping to find it. Filters, because it is commonly used for filter menus and toggles on various websites.

Both tags have been suggested in #1060 and it displays that people might search for these tags and not find what they are looking for.