### PR TITLE
chore(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,32 @@
+name: 🐛 Bug Report
+description: Report a bug in the ion-icon component. Incorrect icons should use the "Incorrect Icon" template instead.
+labels: ["triage"]
+title: "bug: "
+body:
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A clear description of what the bug is and how it manifests.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A clear description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: Please explain the steps required to duplicate this issue.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Code Reproduction URL
+      description: Please provide an application with the minimum code required to reproduce the issue. This is the best way to ensure this issue is triaged quickly. Issues without a code reproduction may be closed if the Ionic Team cannot reproduce the issue you are reporting.
+      placeholder: https://github.com/...
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: List any other information that is relevant to your issue. Stack traces, related issues, suggestions on how to fix, Stack Overflow links, forum links, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: 💡 Feature Request
+description: Suggest a new feature for the ion-icon component. Icon requests should use the "Icon Request" template instead.
+labels: ["triage"]
+title: "feat: "
+body:
+  - type: textarea
+    attributes:
+      label: Describe Problem
+      description: A clear and concise description of what the problem is. Ex. I am always frustrated when [...]
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe Preferred Solution
+      description: A clear and concise description of what you want to happen.
+  - type: textarea
+    attributes:
+      label: Describe Alternatives
+      description: A clear and concise description of any alternative solutions or features you have considered.
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/icon_request.yml
+++ b/.github/ISSUE_TEMPLATE/icon_request.yml
@@ -1,0 +1,18 @@
+name: 🚀 Icon Request
+description: Request a new icon
+labels: ["triage"]
+body:
+  - type: textarea
+    attributes:
+      label: Describe the Icon
+      description: A clear and concise description of the icon you would like added.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Links to Examples
+      description: Add links to any examples of the icon in other libraries that you like.
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: Add any other context about the icon request here.

--- a/.github/ISSUE_TEMPLATE/icon_request.yml
+++ b/.github/ISSUE_TEMPLATE/icon_request.yml
@@ -1,6 +1,7 @@
 name: 🚀 Icon Request
 description: Request a new icon
 labels: ["triage"]
+title: "icon request: "
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/incorrect_icon.yml
+++ b/.github/ISSUE_TEMPLATE/incorrect_icon.yml
@@ -1,6 +1,7 @@
 name: 😒 Incorrect Icon
 description: Report an incorrect icon.
 labels: ["triage"]
+title: "incorrect icon: "
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/incorrect_icon.yml
+++ b/.github/ISSUE_TEMPLATE/incorrect_icon.yml
@@ -1,17 +1,17 @@
 name: 😒 Incorrect Icon
-description: Report an incorrect icon.
+description: Report an incorrect icon
 labels: ["triage"]
 title: "incorrect icon: "
 body:
   - type: textarea
     attributes:
       label: Describe the Issue
-      description: A clear description of what is wrong with the icon. Please include screenshots that you think are relevant.
+      description: A clear description of what is wrong with the icon. Please include any relevant screenshots.
     validations:
       required: true
   - type: textarea
     attributes:
       label: Expected Behavior
-      description: A clear description of what the icon should look like. Please include screenshots that you think are relevant.
+      description: A clear description of what the icon should look like. Please include any relevant screenshots.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/incorrect_icon.yml
+++ b/.github/ISSUE_TEMPLATE/incorrect_icon.yml
@@ -1,0 +1,16 @@
+name: 😒 Incorrect Icon
+description: Report an incorrect icon.
+labels: ["triage"]
+body:
+  - type: textarea
+    attributes:
+      label: Describe the Issue
+      description: A clear description of what is wrong with the icon. Please include screenshots that you think are relevant.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A clear description of what the icon should look like. Please include screenshots that you think are relevant.
+    validations:
+      required: true


### PR DESCRIPTION
Adds templates for the following types:

- Bugs in the ion-icon component
- Feature requests for the ion-icon component
- Issues with the icon SVG data
- Icon requests