### PR TITLE
chore(ci): add update screenshots stub

### DIFF
--- a/.github/workflows/update-screenshots.yml
+++ b/.github/workflows/update-screenshots.yml
@@ -1,0 +1,11 @@
+name: 'Update Screenshot References'
+
+on:
+  workflow_dispatch:
+
+jobs:
+  stub:
+    steps:
+      - name: Stub
+        run: echo 'This is a stub'
+        shell: bash


### PR DESCRIPTION
This job will not show up from https://github.com/ionic-team/ionicons/actions unless I first merge a file into `main`. This stub will allow me to test the actual implementation in a separate branch.