### PR TITLE
fix(icon): icons will load when content security policies are enabled

### DIFF
--- a/src/components/test/csp/icon.e2e.ts
+++ b/src/components/test/csp/icon.e2e.ts
@@ -1,0 +1,15 @@
+import { expect } from '@playwright/test';
+import { test } from '../../../utils/test/playwright';
+
+test.describe('icon: csp', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/test/csp');
+  });
+
+  test('should load svg', async ({ page }) => {
+    const svg = page.locator('ion-icon#icon-usage svg');
+    await expect(svg).toBeVisible();
+  });
+
+});

--- a/src/components/test/csp/index.html
+++ b/src/components/test/csp/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en" mode="ios">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/*; img-src 'self'; connect-src 'self'; font-src https://fonts.gstatic.com/*'">
+  <title>IonIcon - Content Security Policy</title>
+  <script type="module" src="../../build/ionicons.esm.js"></script>
+  <script nomodule src="../../build/ionicons.js"></script>
+  <style>
+    body {
+      margin: 0;
+      padding: 16px;
+      font-size: 32px;
+      font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    }
+
+    h1 {
+      margin: 15px 0 5px;
+      font-size: 25px;
+    }
+
+    h2 {
+      margin: 15px 0 5px;
+      font-size: 18px;
+    }
+
+    .custom {
+      stroke: red;
+      fill: blue;
+    }
+  </style>
+</head>
+
+<body>
+  <h1>Ionicons - Test </h1>
+
+  <h2>Default</h2>
+  <ion-icon src="/assets/chat.svg"></ion-icon>
+  <ion-icon name="add"></ion-icon>
+
+</body>
+
+</html>

--- a/src/components/test/csp/index.html
+++ b/src/components/test/csp/index.html
@@ -29,7 +29,8 @@
 
     .custom {
       stroke: red;
-      fill: blue;
+      fill: goldenrod;
+      color: black;
     }
   </style>
 </head>
@@ -41,6 +42,13 @@
   <ion-icon src="/assets/chat.svg"></ion-icon>
   <ion-icon name="add"></ion-icon>
 
+  <ion-icon id="icon-usage"
+    icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'><title>Watch</title><rect x='136' y='136' width='240' height='240' rx='8' ry='8'/><path d='M384 96h-48V16H176v80h-48a32 32 0 00-32 32v256a32 32 0 0032 32h48v80h160v-80h48a32 32 0 0032-32V128a32 32 0 00-32-32zm8 272a24 24 0 01-24 24H144a24 24 0 01-24-24V144a24 24 0 0124-24h224a24 24 0 0124 24z'/></svg>">
+  </ion-icon>
+
+  <ion-icon class="custom"
+    icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'><title>Watch</title><rect x='136' y='136' width='240' height='240' rx='8' ry='8'/><path d='M384 96h-48V16H176v80h-48a32 32 0 00-32 32v256a32 32 0 0032 32h48v80h160v-80h48a32 32 0 0032-32V128a32 32 0 00-32-32zm8 272a24 24 0 01-24 24H144a24 24 0 01-24-24V144a24 24 0 0124-24h224a24 24 0 0124 24z'/></svg>">
+  </ion-icon>
 </body>
 
 </html>

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -22,6 +22,14 @@ export const config: Config = {
           src: './components/test/*.svg',
           dest: './assets/',
         },
+        {
+          src: './svg/*.svg',
+          dest: './build/svg/',
+        },
+        {
+          src: './components/test/',
+          dest: './test/',
+        }
       ],
       empty: false,
       serviceWorker: false,


### PR DESCRIPTION
**Background**

When content security policies (CSP) are enabled, the usage of `<ion-icon icon={icon}>` fails to load, due to the url being a `data:` uri. 

e.g.:

With a CSP of:
```
default-src 'none'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/*; img-src 'self'; connect-src 'self'; font-src https://fonts.gstatic.com/*'
```

**What's new**
- Icons with a data url will be parsed using the [`DOMParser`](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser), allowing the asset to safely load
- `<ion-icon icon={icon}>` will render when a CSP is enabled. 