### PR TITLE
chore: exclude playwright test infra and test svg assets from collection output

### DIFF
--- a/scripts/collection-copy.ts
+++ b/scripts/collection-copy.ts
@@ -9,6 +9,8 @@ async function collectionCopy(rootDir: string) {
 
   // we don't to copy the src svgs to collection
   await fs.remove(join(rootDir, 'dist', 'collection', 'svg'));
+  // We don't want to copy the test svg assets to collection
+  await fs.remove(join(rootDir, 'dist', 'collection', 'components', 'test'));
 
   const cePackageDir = join(rootDir, 'components');
   const cePackageJsonPath = join(cePackageDir, 'package.json');
@@ -26,7 +28,7 @@ async function collectionCopy(rootDir: string) {
     private: true,
   };
   await fs.writeFile(cePackageJsonPath, JSON.stringify(cePackageJson, null, 2));
-  
+
   /**
    * TODO: Remove this in Ionicons v6.0
    * Stencil 2 removed the legacy loader,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,10 +6,7 @@
     "allowUnreachableCode": false,
     "declaration": false,
     "experimentalDecorators": true,
-    "lib": [
-      "dom",
-      "es2017"
-    ],
+    "lib": ["dom", "es2017"],
     "moduleResolution": "node",
     "module": "esnext",
     "target": "es2017",
@@ -21,10 +18,6 @@
       "@utils/*": ["src/utils/*"]
     }
   },
-  "include": [
-    "src"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/utils/test"]
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,4 @@
+{
+  "extends": "tsconfig.json",
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Updates the `tsconfig.json` to exclude the `src/utils/test` infrastructure for Playwright from being copied into the collection output when performing a build. Also excludes the test svg assets from being copied into the collection output.