### PR TITLE
chore(ci): add release CI stub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,10 @@
+name: 'Ionicons Production Release'
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-dev-hash:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo stub


### PR DESCRIPTION
This PR adds a stubbed implementation of the Ionicons release process so I can test in a branch.