### PR TITLE
chore(ci): do not tag release for dev builds

### DIFF
--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: Update Version
-      run: npm version ${{ inputs.version }}
+      run: npm version ${{ inputs.version }} --git-tag-version false
       shell: bash
       working-directory: ${{ inputs.working-directory }}
     - name: Run Build
@@ -37,6 +37,6 @@ runs:
       env:
         NPM_TOKEN: ${{ inputs.token }}
     - name: Publish to NPM
-      run: npm publish ${{ inputs.folder }} --tag ${{ inputs.tag }}  --git-tag-version false
+      run: npm publish ${{ inputs.folder }} --tag ${{ inputs.tag }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "start": "stencil build --dev --watch --serve",
     "test": "npm run test.spec",
     "test.spec": "stencil test --spec",
-    "release": "np --no-2fa",
-    "version": "npm run build"
+    "release": "np --no-2fa"
   },
   "dependencies": {
     "@stencil/core": "^2.18.0"


### PR DESCRIPTION
- The `--git-tag-version` flag was on the wrong command, so releases were getting tagged. This should not happen for dev builds.
- There was a `version` script causing the build to run twice (once when `npm version` was called then again with `npm run build`)