### PR TITLE
fix(icon): remove auto-generated aria-label

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -1,6 +1,6 @@
 import { Build, Component, Element, Host, Prop, State, Watch, h } from '@stencil/core';
 import { getSvgContent, ioniconContent } from './request';
-import { getName, getUrl, inheritAttributes, isRTL } from './utils';
+import { getUrl, inheritAttributes, isRTL } from './utils';
 
 let parser: DOMParser;
 
@@ -162,16 +162,6 @@ export class Icon {
           getSvgContent(url, this.sanitize).then(() => (this.svgContent = ioniconContent.get(url)));
         }
       }
-    }
-
-    const label = this.iconName = getName(this.name, this.icon, this.mode, this.ios, this.md);
-
-    /**
-     * Come up with a default label
-     * in case user does not provide their own.
-     */
-    if (label) {
-      this.ariaLabel = label.replace(/\-/g, ' ');
     }
   }
 

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -1,6 +1,6 @@
 import { Build, Component, Element, Host, Prop, State, Watch, h } from '@stencil/core';
 import { getSvgContent, ioniconContent } from './request';
-import { getUrl, inheritAttributes, isRTL } from './utils';
+import { getName, getUrl, inheritAttributes, isRTL } from './utils';
 
 let parser: DOMParser;
 
@@ -156,6 +156,8 @@ export class Icon {
         }
       }
     }
+
+    this.iconName = getName(this.name, this.icon, this.mode, this.ios, this.md);
   }
 
   render() {

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -19,7 +19,6 @@ export class Icon {
 
   @State() private svgContent?: string;
   @State() private isVisible = false;
-  @State() private ariaLabel?: string;
 
   /**
    * The mode determines which platform styles to use.
@@ -124,12 +123,6 @@ export class Icon {
       cb();
     }
   }
-  
-  private hasAriaHidden = () => {
-    const { el } = this;
-    
-    return el.hasAttribute('aria-hidden') && el.getAttribute('aria-hidden') === 'true';
-  }
 
   @Watch('name')
   @Watch('src')
@@ -166,7 +159,7 @@ export class Icon {
   }
 
   render() {
-    const { iconName, ariaLabel, el, inheritedAttributes } = this;
+    const { iconName, el, inheritedAttributes } = this;
     const mode = this.mode || 'md';
     const flipRtl =
       this.flipRtl ||
@@ -174,16 +167,8 @@ export class Icon {
         (iconName.indexOf('arrow') > -1 || iconName.indexOf('chevron') > -1) &&
         this.flipRtl !== false);
 
-    /**
-     * Only set the aria-label if a) we have generated
-     * one for the icon and if aria-hidden is not set to "true".
-     * If developer wants to set their own aria-label, then
-     * inheritedAttributes down below will override whatever
-     * default label we have set.
-     */
     return (
       <Host
-        aria-label={ariaLabel !== undefined && !this.hasAriaHidden() ? ariaLabel : null}
         role="img"
         class={{
           [mode]: true,

--- a/src/components/icon/test/icon.spec.ts
+++ b/src/components/icon/test/icon.spec.ts
@@ -46,21 +46,6 @@ describe('icon', () => {
     `);
   });
   
-  it('renders default aria-label', async () => {
-    const { root } = await newSpecPage({
-      components: [Icon],
-      html: `<ion-icon name="chevron-forward"></ion-icon>`,
-    });
-
-    expect(root).toEqualHtml(`
-      <ion-icon class="md" name="chevron-forward" role="img" aria-label="chevron forward">
-        <mock:shadow-root>
-          <div class="icon-inner"></div>
-        </mock:shadow-root>
-      </ion-icon>
-    `);
-  });
-  
   it('renders custom aria-label', async () => {
     const { root } = await newSpecPage({
       components: [Icon],
@@ -99,36 +84,6 @@ describe('icon', () => {
 
     expect(icon).toEqualHtml(`
       <ion-icon class="md" name="trash" role="img" aria-label="custom label">
-        <mock:shadow-root>
-          <div class="icon-inner"></div>
-        </mock:shadow-root>
-      </ion-icon>
-    `);
-  });
-  
-  it('renders default label after changing source', async () => {
-    const page = await newSpecPage({
-      components: [Icon],
-      html: `<ion-icon name="chevron-forward"></ion-icon>`,
-    });
-    
-    const icon = page.root;
-
-    expect(icon).toEqualHtml(`
-      <ion-icon class="md" name="chevron-forward" role="img" aria-label="chevron forward">
-        <mock:shadow-root>
-          <div class="icon-inner"></div>
-        </mock:shadow-root>
-      </ion-icon>
-    `);
-    
-    if (icon) {
-      icon.name = 'trash';
-    }
-    await page.waitForChanges();
-
-    expect(icon).toEqualHtml(`
-      <ion-icon class="md" name="trash" role="img" aria-label="trash">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>

--- a/src/components/icon/test/icon.spec.ts
+++ b/src/components/icon/test/icon.spec.ts
@@ -16,20 +16,6 @@ describe('icon', () => {
     `);
   });
 
-  it('renders aria-hidden and no aria-label', async () => {
-    const { root } = await newSpecPage({
-      components: [Icon],
-      html: `<ion-icon aria-hidden="true"></ion-icon>`,
-    });
-    expect(root).toEqualHtml(`
-      <ion-icon class="md" role="img" aria-hidden="true">
-        <mock:shadow-root>
-          <div class="icon-inner"></div>
-        </mock:shadow-root>
-      </ion-icon>
-    `);
-  });
-
   it('renders rtl with aria-hidden', async () => {
     const { root } = await newSpecPage({
       components: [Icon],


### PR DESCRIPTION
Currently, `ion-icon` will generate a default `aria-label` based on the icon name if no label is provided by the developer. However, this default label is often not useful as it doesn't give any info on the context the icon is being used in.

This PR removes the default `aria-label` logic as well as tests that pertained to it. Note that custom `aria-label`s are already handled by the `inheritAttributes` util.