### PR TITLE
fix(icon): md and ios properties are reactive

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -134,6 +134,8 @@ export class Icon {
   @Watch('name')
   @Watch('src')
   @Watch('icon')
+  @Watch('ios')
+  @Watch('md')
   loadIcon() {
     if (Build.isBrowser && this.isVisible) {
       if (!parser) {


### PR DESCRIPTION
resolves https://github.com/ionic-team/ionic-framework/issues/26712, resolves https://github.com/ionic-team/ionicons/issues/802

There is no watcher for the `ios` or `md` properties, so changing these values does not cause the rendered icon to be changed. Note: The `mode` property is not reactive in Ionic Framework, so I kept the behavior consistent here.