### PR TITLE
fix: DomParser usage in SSR

### DIFF
--- a/src/components/icon/request.ts
+++ b/src/components/icon/request.ts
@@ -1,4 +1,3 @@
-import { Build } from '@stencil/core';
 import { isEncodedDataUrl, isSvgDataUrl, validateContent } from './validate';
 
 export const ioniconContent = new Map<string, string>();
@@ -16,7 +15,7 @@ export const getSvgContent = (url: string, sanitize: boolean) => {
        * If the url is a data url of an svg, then try to parse it
        * with the DOMParser. This works with content security policies enabled.
        */
-      if (isSvgDataUrl(url) && isEncodedDataUrl(url) && Build.isBrowser) {
+      if (isSvgDataUrl(url) && isEncodedDataUrl(url)) {
         if (!parser) {
           /**
            * Create an instance of the DOM parser. This creates a single

--- a/src/components/icon/request.ts
+++ b/src/components/icon/request.ts
@@ -1,9 +1,10 @@
+import { Build } from '@stencil/core';
 import { isEncodedDataUrl, isSvgDataUrl, validateContent } from './validate';
 
 export const ioniconContent = new Map<string, string>();
 const requests = new Map<string, Promise<any>>();
 
-let parser = new DOMParser();
+let parser: DOMParser;
 
 export const getSvgContent = (url: string, sanitize: boolean) => {
   // see if we already have a request for this url
@@ -15,7 +16,7 @@ export const getSvgContent = (url: string, sanitize: boolean) => {
        * If the url is a data url of an svg, then try to parse it
        * with the DOMParser. This works with content security policies enabled.
        */
-      if (isSvgDataUrl(url) && isEncodedDataUrl(url)) {
+      if (isSvgDataUrl(url) && isEncodedDataUrl(url) && Build.isBrowser) {
         if (!parser) {
           /**
            * Create an instance of the DOM parser. This creates a single


### PR DESCRIPTION
The `DomParser` class is not available in a server context (only available in the browser). The previous changes were causing issues in SSR when trying to load an icon.

This PR removes the implementation of instantiating the `DomParser`, regardless of the environment. 

Resolves: https://github.com/ionic-team/ionicons/issues/1179