### PR TITLE
fix(icon): add fallback for safari 16.4

### DIFF
--- a/src/components/icon/icon.css
+++ b/src/components/icon/icon.css
@@ -54,8 +54,10 @@ svg {
  * is not updated if the document dir
  * is dynamically changed: https://bugs.webkit.org/show_bug.cgi?id=257133
  */
-:host(.icon-rtl) .icon-inner {
-  transform: scaleX(-1);
+@supports not selector(:dir(rtl)) {
+  :host(.icon-rtl) .icon-inner {
+    transform: scaleX(-1);
+  }
 }
 
 /* Icon Sizes

--- a/src/components/icon/icon.css
+++ b/src/components/icon/icon.css
@@ -47,6 +47,17 @@ svg {
   }
 }
 
+/**
+ * Fallback for browsers that support neither :dir nor
+ * :host-context. This also serves as a fallback for
+ * Safari 16.4 which has a bug where the :dir
+ * is not updated if the document dir
+ * is dynamically changed: https://bugs.webkit.org/show_bug.cgi?id=257133
+ */
+:host(.icon-rtl) .icon-inner {
+  transform: scaleX(-1);
+}
+
 /* Icon Sizes
  * -----------------------------------------------------------
  */

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -1,6 +1,6 @@
 import { Build, Component, Element, Host, Prop, State, Watch, h } from '@stencil/core';
 import { getSvgContent, ioniconContent } from './request';
-import { getName, getUrl, inheritAttributes } from './utils';
+import { getName, getUrl, inheritAttributes, isRTL } from './utils';
 
 @Component({
   tag: 'ion-icon',
@@ -145,7 +145,7 @@ export class Icon {
   }
 
   render() {
-    const { flipRtl, iconName, inheritedAttributes } = this;
+    const { flipRtl, iconName, inheritedAttributes, el } = this;
     const mode = this.mode || 'md';
     // we have designated that arrows & chevrons should automatically flip (unless flip-rtl is set to false) because "back" is left in ltr and right in rtl, and "forward" is the opposite
     const shouldAutoFlip = iconName
@@ -162,6 +162,7 @@ export class Icon {
           ...createColorClasses(this.color),
           [`icon-${this.size}`]: !!this.size,
           'flip-rtl': shouldBeFlippable,
+          'icon-rtl': shouldBeFlippable && isRTL(el)
         }}
         {...inheritedAttributes}
       >

--- a/src/components/icon/test/icon.spec.ts
+++ b/src/components/icon/test/icon.spec.ts
@@ -24,7 +24,7 @@ describe('icon', () => {
     });
 
     expect(root).toEqualHtml(`
-      <ion-icon class="md flip-rtl" name="chevron-forward" role="img" aria-hidden="true">
+      <ion-icon class="md flip-rtl icon-rtl" name="chevron-forward" role="img" aria-hidden="true">
         <mock:shadow-root>
           <div class="icon-inner"></div>
         </mock:shadow-root>

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -140,3 +140,17 @@ export const inheritAttributes = (el: HTMLElement, attributes: string[] = []) =>
 
   return attributeObject;
 }
+
+/**
+ * Returns `true` if the document or host element
+ * has a `dir` set to `rtl`. The host value will always
+ * take priority over the root document value.
+ */
+export const isRTL = (hostEl?: Pick<HTMLElement, 'dir'>) => {
+  if (hostEl) {
+    if (hostEl.dir !== '') {
+      return hostEl.dir.toLowerCase() === 'rtl';
+    }
+  }
+  return document?.dir.toLowerCase() === 'rtl';
+};


### PR DESCRIPTION
Safari 16.4 has a bug where dynamically changing the document `dir` for the first time does not cause styles that use `:dir` to update. This new fallback allows icons to still flip correctly in the event the document `dir` changes before the component loads. If the document `dir` changes again, then Safari/WebKit will correctly re-render.

WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=257133

This WebKit bug is causing visual diffs in Ionic Framework with screenshots with `ion-back-button` because adding `?rtl=true` to the URL causes the testing scripts to update the document `dir` asynchronously: https://github.com/ionic-team/ionic-framework/pull/27540/commits/df7af96dba3599c00ad24f7efd11c35680c13535

This behavior should not impact applications that start with the desired document `dir`. This would impact applications that change the document `dir` dynamically. However, even before this fix developers would have encountered https://github.com/ionic-team/ionicons/issues/1196 with the `ion-back-button` so there would have been no visual change.