### PR TITLE
feat: allow passing in only icon SVG data to addIcons

### DIFF
--- a/src/components/icon/test/utils.spec.ts
+++ b/src/components/icon/test/utils.spec.ts
@@ -1,5 +1,5 @@
 import { Icon } from '../icon';
-import { getName, getSrc, getUrl } from '../utils';
+import { addIcons, getIconMap, getName, getSrc, getUrl } from '../utils';
 
 
 describe('getUrl', () => {
@@ -81,4 +81,28 @@ describe('getName', () => {
     expect(getName(undefined, undefined, '', '', '')).toBe(null);
   });
 
+});
+
+describe('addIcons', () => {
+  it('should add an svg to the icon cache', () => {
+    const testData = 'stubbed data';
+    
+    expect(getIconMap().get('logo-ionic')).toEqual(undefined);
+    
+    addIcons({ 'logo-ionic': 'stubbed data' });
+    
+    expect(getIconMap().get('logo-ionic')).toEqual(testData);
+  });
+  
+  it('should add kebab and camel case names to the icon cache', () => {
+    const logoIonitron = 'stubbed data';
+    
+    expect(getIconMap().get('logo-ionitron')).toEqual(undefined);
+    expect(getIconMap().get('logoIonitron')).toEqual(undefined);
+    
+    addIcons({ logoIonitron });
+    
+    expect(getIconMap().get('logo-ionitron')).toEqual(logoIonitron);
+    expect(getIconMap().get('logoIonitron')).toEqual(logoIonitron);
+  });
 });

--- a/src/components/icon/test/utils.spec.ts
+++ b/src/components/icon/test/utils.spec.ts
@@ -137,4 +137,16 @@ describe('addIcons', () => {
     expect(getIconMap().get('logo-a')).toEqual(logoB);
     expect(getIconMap().get('logoA')).toEqual(logoA);
   });
+  
+  it('passing kebab case key should not generate a camel case key', () => {
+    const logoIonitron = 'stubbed data';
+    
+    expect(getIconMap().get('kebab-key')).toEqual(undefined);
+    expect(getIconMap().get('kebabKey')).toEqual(undefined);
+    
+    addIcons({ 'kebab-key': logoIonitron });
+    
+    expect(getIconMap().get('kebab-key')).toEqual(logoIonitron);
+    expect(getIconMap().get('kebabKey')).toEqual(undefined);
+  });
 });

--- a/src/components/icon/test/utils.spec.ts
+++ b/src/components/icon/test/utils.spec.ts
@@ -125,4 +125,16 @@ describe('addIcons', () => {
     
     expect(getIconMap().get('myCoolIcon')).toEqual(logoIonitron);
   });
+  
+  it('should not overwrite icons', () => {
+    const logoA = 'logo a';
+    const logoB = 'logo b';
+    
+    expect(getIconMap().get('logo-a')).toEqual(undefined);
+    
+    addIcons({ 'logo-a': logoB, logoA });
+    
+    expect(getIconMap().get('logo-a')).toEqual(logoB);
+    expect(getIconMap().get('logoA')).toEqual(logoA);
+  });
 });

--- a/src/components/icon/test/utils.spec.ts
+++ b/src/components/icon/test/utils.spec.ts
@@ -115,4 +115,14 @@ describe('addIcons', () => {
     
     expect(getIconMap().get('my-fun-icon')).toEqual(logoIonitron);
   });
+  
+  it('should map to an explicit camel case name', () => {
+    const logoIonitron = 'stubbed data';
+    
+    expect(getIconMap().get('myCoolIcon')).toEqual(undefined);
+    
+    addIcons({ 'myCoolIcon': logoIonitron });
+    
+    expect(getIconMap().get('myCoolIcon')).toEqual(logoIonitron);
+  });
 });

--- a/src/components/icon/test/utils.spec.ts
+++ b/src/components/icon/test/utils.spec.ts
@@ -105,4 +105,14 @@ describe('addIcons', () => {
     expect(getIconMap().get('logo-ionitron')).toEqual(logoIonitron);
     expect(getIconMap().get('logoIonitron')).toEqual(logoIonitron);
   });
+  
+  it('should map to a name that does not match the svg', () => {
+    const logoIonitron = 'stubbed data';
+    
+    expect(getIconMap().get('my-fun-icon')).toEqual(undefined);
+    
+    addIcons({ 'my-fun-icon': logoIonitron });
+    
+    expect(getIconMap().get('my-fun-icon')).toEqual(logoIonitron);
+  });
 });

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -29,7 +29,7 @@ export const addIcons = (icons: { [name: string]: string; }) => {
      * an "add-circle-outline" entry.
      * Usage: <ion-icon name="add-circle-outline"></ion-icon>
      * Using name="addCircleOutline" is valid too, but the
-     * the kebab case naming is preferred.
+     * kebab case naming is preferred.
      */
     const toKebabCase = name.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, "$1-$2").toLowerCase();
     if (name !== toKebabCase) {

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -19,7 +19,24 @@ export const getIconMap = (): Map<string, string> => {
 
 export const addIcons = (icons: { [name: string]: string; }) => {
   const map = getIconMap();
-  Object.keys(icons).forEach(name => map.set(name, icons[name]));
+  Object.keys(icons).forEach(name => {
+    const toKebabCase = name.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, "$1-$2").toLowerCase();
+    map.set(name, icons[name]);
+    
+    /**
+     * Developers can also pass in the SVG object directly
+     * and Ionicons can map the object to a kebab case name.
+     * Example: addIcons({ addCircleOutline });
+     * This will create an "addCircleOutline" entry and
+     * an "add-circle-outline" entry.
+     * Usage: <ion-icon name="add-circle-outline"></ion-icon>
+     * Using name="addCircleOutline" is valid too, but the
+     * the kebab case naming is preferred.
+     */
+    if (name !== toKebabCase) {
+      map.set(toKebabCase, icons[name]);
+    }
+  });
 };
 
 

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -18,10 +18,8 @@ export const getIconMap = (): Map<string, string> => {
 };
 
 export const addIcons = (icons: { [name: string]: string; }) => {
-  const map = getIconMap();
-  Object.keys(icons).forEach(name => {
-    const toKebabCase = name.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, "$1-$2").toLowerCase();
-    map.set(name, icons[name]);
+  Object.keys(icons).forEach(name => {    
+    addToIconMap(name, icons[name]);
     
     /**
      * Developers can also pass in the SVG object directly
@@ -33,11 +31,22 @@ export const addIcons = (icons: { [name: string]: string; }) => {
      * Using name="addCircleOutline" is valid too, but the
      * the kebab case naming is preferred.
      */
+    const toKebabCase = name.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, "$1-$2").toLowerCase();
     if (name !== toKebabCase) {
-      map.set(toKebabCase, icons[name]);
+      addToIconMap(toKebabCase, icons[name]);
     }
   });
 };
+
+const addToIconMap = (name: string, data: any) => {
+  const map = getIconMap();
+
+  if (map.get(name) === undefined) {
+    map.set(name, data);
+  } else {
+    console.warn(`[Ionicons Warning]: Multiple icons were mapped to name "${name}". Ensure that multiple icons are not mapped to the same icon name.`)
+  }
+}
 
 
 export const getUrl = (i: Icon) => {


### PR DESCRIPTION
See https://github.com/ionic-team/ionic-framework-design-documents/commit/a12daf314e9fdd6619503e88e9c99d2c184d95b7

This feature allows developers to pass icons to the icon map without explicitly setting the string name. This cuts down on boilerplate and reduces the likelihood of mapping the icon to a typo (i.e. `"log-ionic"` instead of `"logo-ionic"`)

For backwards compatibility purposes, the camel case key will still be available for developers who are explicitly mapping icon SVG data to camel case keys.

As part of this, Ionicons will now warn if multiple icons are mapped to the same key. TypeScript should prevent devs from explicitly doing this in Objects, but by autogenerating keys this may happen without the developer knowing. A warning will be logged so devs are aware of when this happens.

**Usage**

```typescript
/**
 * Yields "logo-ionic" and "logoIonic" keys in the map
 */
addIcons({ 'logoIonic': logoIonic });

/**
 * Yields "logo-ionic" key in the map
 */
addIcons({ 'logo-ionic': logoIonic });

/**
 * Yields "logo-ionic" and "logoIonic" keys in the map
 */
addIcons({ logoIonic });

/**
 * "logo-a" key maps to logoB object, and a warning is logged for the logoA object.
 */
addIcons({ 'logo-a': logoB, logoA });
```