### PR TITLE
chore(print): add fax to tags

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -8456,24 +8456,24 @@
     {
       "name": "print",
       "tags": [
-        "print",
-        "fax"
+        "fax",
+        "print"
       ]
     },
     {
       "name": "print-outline",
       "tags": [
+        "fax",
         "outline",
-        "print",
-        "fax"
+        "print"
       ]
     },
     {
       "name": "print-sharp",
       "tags": [
+        "fax",
         "print",
-        "sharp",
-        "fax"
+        "sharp"
       ]
     },
     {

--- a/src/data.json
+++ b/src/data.json
@@ -8456,21 +8456,24 @@
     {
       "name": "print",
       "tags": [
-        "print"
+        "print",
+        "fax"
       ]
     },
     {
       "name": "print-outline",
       "tags": [
         "outline",
-        "print"
+        "print",
+        "fax"
       ]
     },
     {
       "name": "print-sharp",
       "tags": [
         "print",
-        "sharp"
+        "sharp",
+        "fax"
       ]
     },
     {


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

There are no associated icons when searching for `fax`.

## What is the new behavior?

The `print` icon can also be used as a `fax` logo. When searching for the `fax` then the `print` icon will be provided.

![Screenshot 2023-09-07 at 9 24 56 AM](https://github.com/ionic-team/ionicons/assets/13530427/bf4f0e98-ee7c-435b-a09f-6219165aa379)


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Determined through this [icon request](https://github.com/ionic-team/ionicons/issues/1271#issuecomment-1710409700).