### PR TITLE
fix(icon): verify the icon loads in the lifecycle

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -12,6 +12,7 @@ export class Icon {
   private io?: IntersectionObserver;
   private iconName: string | null = null;
   private inheritedAttributes: { [k: string]: any } = {};
+  private didLoadIcon = false;
 
   @Element() el!: HTMLElement;
 
@@ -94,6 +95,12 @@ export class Icon {
     });
   }
 
+  componentDidLoad() {
+    if (!this.didLoadIcon) {
+      this.loadIcon();
+    }
+  }
+
   disconnectedCallback() {
     if (this.io) {
       this.io.disconnect();
@@ -138,6 +145,7 @@ export class Icon {
           // async if it hasn't been loaded
           getSvgContent(url, this.sanitize).then(() => (this.svgContent = ioniconContent.get(url)));
         }
+        this.didLoadIcon = true;
       }
     }
 

--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -96,6 +96,12 @@ export class Icon {
   }
 
   componentDidLoad() {
+    /**
+     * Addresses an Angular issue where property values are assigned after the 'connectedCallback' but prior to the registration of watchers.
+     * This enhancement ensures the loading of an icon when the component has finished rendering and the icon has yet to apply the SVG data.
+     * This modification pertains to the usage of Angular's binding syntax:
+     * `<ion-icon [name]="myIconName"></ion-icon>`
+     */
     if (!this.didLoadIcon) {
       this.loadIcon();
     }


### PR DESCRIPTION
Issue URL: N/A


## What is the current behavior?

Icons won't load when using Angular binding.

## What is the new behavior?

Icons now load when using Angular binding.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

N/A