### PR TITLE
fix(icon): mapping same icon does not warn

### DIFF
--- a/src/components/icon/test/utils.spec.ts
+++ b/src/components/icon/test/utils.spec.ts
@@ -126,9 +126,29 @@ describe('addIcons', () => {
     expect(getIconMap().get('myCoolIcon')).toEqual(logoIonitron);
   });
   
+  it('should not warn when mapping the same icon twice', () => {
+    const spy = jest.spyOn(console, 'warn');
+
+    const myIcon = 'my-icon';
+    
+    expect(spy).not.toHaveBeenCalled();
+ 
+    addIcons({ myIcon });
+    
+    expect(spy).not.toHaveBeenCalled();
+    
+    addIcons({ myIcon });
+    
+    expect(spy).not.toHaveBeenCalled();
+  });
+  
   it('should not overwrite icons', () => {
+    const spy = jest.spyOn(console, 'warn');
+    
     const logoA = 'logo a';
     const logoB = 'logo b';
+    
+    expect(spy).not.toHaveBeenCalled();
     
     expect(getIconMap().get('logo-a')).toEqual(undefined);
     
@@ -136,17 +156,8 @@ describe('addIcons', () => {
     
     expect(getIconMap().get('logo-a')).toEqual(logoB);
     expect(getIconMap().get('logoA')).toEqual(logoA);
+    
+    expect(spy).toHaveBeenCalled();
   });
   
-  it('passing kebab case key should not generate a camel case key', () => {
-    const logoIonitron = 'stubbed data';
-    
-    expect(getIconMap().get('kebab-key')).toEqual(undefined);
-    expect(getIconMap().get('kebabKey')).toEqual(undefined);
-    
-    addIcons({ 'kebab-key': logoIonitron });
-    
-    expect(getIconMap().get('kebab-key')).toEqual(logoIonitron);
-    expect(getIconMap().get('kebabKey')).toEqual(undefined);
-  });
 });

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -47,9 +47,9 @@ const addToIconMap = (name: string, data: any) => {
     map.set(name, data);
     
   /**
-   * Importing and defining the same icon reference
-   * multiple times should not yield a warning.
-   */
+  
+* Importing and defining the same icon reference
+   * multiple times should not yield a warning.   */
   } else if (existingIcon !== data) {
     console.warn(`[Ionicons Warning]: Multiple icons were mapped to name "${name}". Ensure that multiple icons are not mapped to the same icon name.`)
   }

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -47,9 +47,9 @@ const addToIconMap = (name: string, data: any) => {
     map.set(name, data);
     
   /**
-  
-* Importing and defining the same icon reference
-   * multiple times should not yield a warning.   */
+   * Importing and defining the same icon reference
+   * multiple times should not yield a warning.
+   */
   } else if (existingIcon !== data) {
     console.warn(`[Ionicons Warning]: Multiple icons were mapped to name "${name}". Ensure that multiple icons are not mapped to the same icon name.`)
   }

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -40,10 +40,17 @@ export const addIcons = (icons: { [name: string]: string; }) => {
 
 const addToIconMap = (name: string, data: any) => {
   const map = getIconMap();
+  
+  const existingIcon = map.get(name);
 
-  if (map.get(name) === undefined) {
+  if (existingIcon === undefined) {
     map.set(name, data);
-  } else {
+    
+  /**
+   * Importing and defining the same icon reference
+   * multiple times should not yield a warning.
+   */
+  } else if (existingIcon !== data) {
     console.warn(`[Ionicons Warning]: Multiple icons were mapped to name "${name}". Ensure that multiple icons are not mapped to the same icon name.`)
   }
 }


### PR DESCRIPTION
While working with Mike to test StarTrack, we discovered that mapping the same icon twice yields a warning when it should not.

**Example**

```typescript
addIcons({ logoIonic });
addIcons({ logoIonic });
```

This can happen in an application where same icon is used in multiple places. In that case it's necessary to call `addIcons` since we don't know which place will be loaded first. In this case, no warning should be logged since these are the same icon references.