### PR TITLE
chore(ci): ensure local version of lerna is used

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,13 @@ jobs:
         git config user.name ionitron
         git config user.email hi@ionicframework.com
       shell: bash
+    # This ensures the local version of Lerna is installed
+    # and that we do not use the global Lerna version
+    - name: Install root dependencies
+      run: npm ci
+      shell: bash
     - name: Create GitHub Release
-      run: lerna version ${{ inputs.version }} --yes --force-publish='*' --conventional-commits --create-release github
+      run: npx lerna version ${{ inputs.version }} --yes --force-publish='*' --conventional-commits --create-release github
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       shell: bash
@@ -55,7 +60,7 @@ jobs:
     # so we do that here.
     - name: Bump Package Lock
       run: |
-        lerna exec "npm install --package-lock-only --legacy-peer-deps"
+        npx lerna exec "npm install --package-lock-only --legacy-peer-deps"
         git add .
         git commit -m "chore(): update package lock files"
         git push


### PR DESCRIPTION
During the recent Ionicons 7.2.0 release the "finalize-release" step failed because the changelog had not been generated: https://github.com/ionic-team/ionicons/actions/runs/6470513416/job/17566942806

I noticed that Lerna 7 was being used which has several breaking changes that we are not accounting for (because we expect Lerna 6). This PR ensures that our release workflow only uses Lerna 6 (the local version). This is similar to https://github.com/ionic-team/ionic-framework/pull/27656