### PR TITLE
fix(icon): add better warning when loading icons

### DIFF
--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -88,7 +88,16 @@ const getNamedUrl = (iconName: string) => {
   if (url) {
     return url;
   }
-  return getAssetPath(`svg/${iconName}.svg`);
+  try {
+    return getAssetPath(`svg/${iconName}.svg`);
+  } catch(e) {
+    /**
+     * In the custom elements build version of ionicons, referencing an icon
+     * by name will throw an invalid URL error because the asset path is not defined.
+     * This catches that error and logs something that is more developer-friendly.
+     */
+    console.warn(`[Ionicons Warning]: Could not load icon with name "${name}". Ensure that the icon is registered using addIcons or that the icon SVG data is passed directly to the icon component.`);
+  }
 };
 
 

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -96,7 +96,7 @@ const getNamedUrl = (iconName: string) => {
      * by name will throw an invalid URL error because the asset path is not defined.
      * This catches that error and logs something that is more developer-friendly.
      */
-    console.warn(`[Ionicons Warning]: Could not load icon with name "${name}". Ensure that the icon is registered using addIcons or that the icon SVG data is passed directly to the icon component.`);
+    console.warn(`[Ionicons Warning]: Could not load icon with name "${iconName}". Ensure that the icon is registered using addIcons or that the icon SVG data is passed directly to the icon component.`);
   }
 };
 

--- a/src/components/icon/utils.ts
+++ b/src/components/icon/utils.ts
@@ -64,7 +64,7 @@ export const getUrl = (i: Icon) => {
 
   url = getName(i.name, i.icon, i.mode, i.ios, i.md);
   if (url) {
-    return getNamedUrl(url);
+    return getNamedUrl(url, i);
   }
 
   if (i.icon) {
@@ -83,7 +83,7 @@ export const getUrl = (i: Icon) => {
 };
 
 
-const getNamedUrl = (iconName: string) => {
+const getNamedUrl = (iconName: string, iconEl: Icon) => {
   const url = getIconMap().get(iconName);
   if (url) {
     return url;
@@ -95,8 +95,10 @@ const getNamedUrl = (iconName: string) => {
      * In the custom elements build version of ionicons, referencing an icon
      * by name will throw an invalid URL error because the asset path is not defined.
      * This catches that error and logs something that is more developer-friendly.
+     * We also include a reference to the ion-icon element so developers can
+     * figure out which instance of ion-icon needs to be updated.
      */
-    console.warn(`[Ionicons Warning]: Could not load icon with name "${iconName}". Ensure that the icon is registered using addIcons or that the icon SVG data is passed directly to the icon component.`);
+    console.warn(`[Ionicons Warning]: Could not load icon with name "${iconName}". Ensure that the icon is registered using addIcons or that the icon SVG data is passed directly to the icon component.`, iconEl);
   }
 };
 


### PR DESCRIPTION
In https://github.com/ionic-team/ionic-framework/issues/28445 we received feedback that accidentally referring to an icon by name without first registering it is confusing because devs get a cryptic "invalid URL" error. This PR attempts to improve that experience by providing a more helpful message and giving developers steps they can take to fix the issue.

| `main` | branch |
| - | - |
| ![image](https://github.com/ionic-team/ionicons/assets/2721089/7d8bbf50-0ba6-4f2a-ac15-2a6f67e7834b) | ![image](https://github.com/ionic-team/ionicons/assets/2721089/864ee53d-8941-4d9a-a661-60afdc99a184) |

One note: This warning will be logged every time the icons tries to load. We currently load the icon in `connectedCallback` and `componentDidLoad`, so this warning can be logged twice on page load. In Angular, one more warning may be logged if the icon is in a router outlet (since the elements are moved into `ion-router-outlet` on load which means they are first removed from the DOM, so connectedCallback fires twice.). We could add a cache that tracks if we already warned about each icon per element instance if reviewers prefer (though that will slightly increase the complexity of this fix).