### PR TITLE
chore: revert icons lifecycle fix

### DIFF
--- a/src/components/icon/icon.tsx
+++ b/src/components/icon/icon.tsx
@@ -12,7 +12,6 @@ export class Icon {
   private io?: IntersectionObserver;
   private iconName: string | null = null;
   private inheritedAttributes: { [k: string]: any } = {};
-  private didLoadIcon = false;
 
   @Element() el!: HTMLElement;
 
@@ -95,18 +94,6 @@ export class Icon {
     });
   }
 
-  componentDidLoad() {
-    /**
-     * Addresses an Angular issue where property values are assigned after the 'connectedCallback' but prior to the registration of watchers.
-     * This enhancement ensures the loading of an icon when the component has finished rendering and the icon has yet to apply the SVG data.
-     * This modification pertains to the usage of Angular's binding syntax:
-     * `<ion-icon [name]="myIconName"></ion-icon>`
-     */
-    if (!this.didLoadIcon) {
-      this.loadIcon();
-    }
-  }
-
   disconnectedCallback() {
     if (this.io) {
       this.io.disconnect();
@@ -151,7 +138,6 @@ export class Icon {
           // async if it hasn't been loaded
           getSvgContent(url, this.sanitize).then(() => (this.svgContent = ioniconContent.get(url)));
         }
-        this.didLoadIcon = true;
       }
     }
 


### PR DESCRIPTION
This reverts commit 7f7f346af47f45531046e1d2f1a88f53acee77fa. As part of FW-5145 it was determined that this fix did not directly contribute to the resolution of the bug reported in https://github.com/ionic-team/ionicons/pull/1278.

There is a chance that there is a behavior that still reproduces the reported issue that we are missing. However, I would rather have something break so we can a) root-cause the problem and b) add test coverage instead of have some code in the codebase indefinitely where people aren't really sure why it's needed.

Ionicons Dev build: `7.2.2-dev.11700519177.13b28f3a`
Ionic Framework dev build with Ionicons dev build: `7.5.6-dev.11700519388.1583475f`

You can test the dev build with the sidemenu starter app. I've also included a version of Ionic Framework that uses this dev build.