### PR TITLE
chore(ionitron): add auto response for community feedback

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -26,6 +26,7 @@ closeAndLock:
 
 comment:
   labels:
+  
     - label: "help wanted"
       message: >
         This issue has been labeled as `help wanted`. This label is added to issues
@@ -54,6 +55,18 @@ comment:
 
         If you have already provided a code snippet and are seeing this message, it is likely that the code snippet was
         not enough for our team to reproduce the issue.
+    - label: "community feedback wanted"
+      message: >
+        This issue has been labeled as `community feedback wanted`. This label is added to issues that we would like to hear from the community on before moving forward with any final decision on the feature request.
+
+
+        If the requested feature is something you would find useful for your applications, please react to the original post with 👍 (`+1`). If you would like to provide an additional use case for the feature, please post a comment.
+        
+
+        The team will review this feedback and make a final decision. Any decision will be posted on this thread, but please note that we may ultimately decide not to pursue this feature.
+
+
+        Thank you!
   dryRun: false
 
 noReply:

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -26,7 +26,6 @@ closeAndLock:
 
 comment:
   labels:
-  
     - label: "help wanted"
       message: >
         This issue has been labeled as `help wanted`. This label is added to issues


### PR DESCRIPTION
Like on the Ionic Framework repo, we'd like the opportunity to collect community feedback before potentially pursuing features. This adds an auto response for Ionitron when adding the community feedback label.