### PR TITLE
docs(readme): change incorrect module URLs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -26,15 +26,15 @@ Also note that only visible icons are loaded, and icons that are "below the fold
 If you're using [Ionic Framework](https://ionicframework.com/), Ionicons is packaged by default, so no installation is necessary. Want to use Ionicons without Ionic Framework? Place the following `<script>` near the end of your page, right before the closing `</body>` tag, to enable them.
 
 ```html
-<script type="module" src="https://esm.sh/ionicons/loader@latest"></script>
-<script nomodule src="https://esm.sh/ionicons/loader@latest"></script>
+<script type="module" src="https://esm.sh/ionicons@latest/loader"></script>
+<script nomodule src="https://esm.sh/ionicons@latest/loader"></script>
 ```
 
 you can replace `latest` to pick any version of Ionicon, e.g.:
 
 ```html
-<script type="module" src="https://esm.sh/ionicons/loader@8.0.0"></script>
-<script nomodule src="https://esm.sh/ionicons/loader@8.0.0"></script>
+<script type="module" src="https://esm.sh/ionicons@8.0.0/loader"></script>
+<script nomodule src="https://esm.sh/ionicons@8.0.0/loader"></script>
 ```
 
 ### Basic usage


### PR DESCRIPTION
Hi Ionicons team, 

While following the installation guide in the Readme, I noticed that the HTML code snippets for including the Ionicons loader via ESM CDN were not working as expected.

Based on ESM CDN [documentation](https://esm.sh/#docs), the standard URL syntax is typically:
```
https://esm.sh/PKG[@SEMVER][/PATH]
```

Hence, I have updated the URLs to move `/loader` pathname to the end, following the standard format.
https://esm.sh/ionicons@latest/loader

This correction appears to resolve the issue.