### PR TITLE
fix(): export ionicons.json in package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
       "types": "./icons/index.d.ts",
       "import": "./icons/index.mjs",
       "require": "./icons/index.js"
+    },
+    "./dist/ionicons.json": {
+      "default": "./dist/ionicons.json"
     }
   },
   "scripts": {


### PR DESCRIPTION
This change adds `./dist/ionicons.json` to the package exports map to allow consumers to import the JSON file directly. This is useful for tools or libraries that rely on the raw icon metadata.

Without this, importing `ionicons/dist/ionicons.json` throws an `ERR_PACKAGE_PATH_NOT_EXPORTED` error due to the "exports" field restrictions.

This update ensures compatibility with modern module resolution and prevents runtime errors when accessing this file.