### PR TITLE
fix: stencil projects can build ionicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "types": "dist/types/index.d.ts",
   "unpkg": "dist/ionicons/ionicons.esm.js",
   "jsdelivr": "dist/ionicons/ionicons.esm.js",
+  "collection": "dist/collection/collection-manifest.json",
+  "collection:main": "dist/collection/index.js",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -6,7 +6,7 @@ export const config: Config = {
   outputTargets: [
     {
       type: 'dist',
-      collectionDir: null,
+      collectionDir: './collection',
       empty: false,
     },
     {


### PR DESCRIPTION
The collections directory is used by consuming Stencil projects to append a project built with Stencil, to the build context of the current project using Stencil. It is weird, but means that for a project using Stencil (e.g.: Ionic Framework), to be able to build another project using Stencil (e.g.: Ionicons), it needs to be able to read in the generated collections metadata. I believe this mainly applies to the dist output target.

This was recently disabled/removed in the v8 work. This is the primary reason for the build error in: https://github.com/ionic-team/ionic-framework/pull/30390. 

There may be other ways to solve this problem. This is the primary way that I am aware resolves it.

Verification steps:
1. Clone the fork
2. Install dependencies: `npm install`
3. Build the project: `npm run build`
4. Observe: collections are generated in `dist/collection`
5. Pack the built output: `npm pack`
6. Copy the .tgz into the `core/` directory of Ionic Framework
7. Install the .tgz: `npm install ./path-to-file`
8. Build Ionic Framework: `npm run build`
9. Observe: Ionic Framework builds successfully