### PR TITLE
fix: add direct ion-icon component import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
       "types": "./components/index.d.ts",
       "import": "./components/index.js"
     },
+    "./components/ion-icon.js": {
+      "types": "./components/ion-icon.d.ts",
+      "import": "./components/ion-icon.js"
+    },
     "./icons": {
       "types": "./icons/index.d.ts",
       "import": "./icons/index.mjs",


### PR DESCRIPTION
Ionic Framework needs the import path otherwise it throws this error:

```
src/index.ts → dist/...
(!) Plugin typescript: @rollup/plugin-typescript TS2307: Cannot find module 'ionicons/components/ion-icon.js' or its corresponding type declarations.
src/components/IonIcon.ts: (2:37)

2 import { defineCustomElement } from "ionicons/components/ion-icon.js";
```

Verification steps:

1. Clone this PR branch
1. Install dependencies: `npm install`
1. Build and pack the project: `npm run build && npm pack`
1. Copy the .tgz into `~/Downloads`:  `cp ionicons-*.tgz ~/Downloads/ionicons.tgz`
1. Navigate to `packages/vue` in `ionic-framework`
1. Install the .tgz: `npm i ~/Downloads/ionicons.tgz`
1. Build Vue: `npm run build`
1. Observe: Ionic Framework builds successfully