### PR TITLE
chore(workflows): refactor github workflows for new npm auth

### DIFF
--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -10,13 +10,9 @@ inputs:
   folder:
     default: './'
     description: 'A folder containing a package.json file.'
-  token:
-    description: 'The NPM authentication token required to publish.'
-
   createRelease:
     description: 'Create a release on GitHub.'
     default: 'false'
-
   ghToken:
     description: 'The GitHub authentication token required to create a release.'
 
@@ -49,12 +45,6 @@ runs:
       run: npm run build
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-    - name: Prepare NPM Token
-      run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-      working-directory: ${{ inputs.working-directory }}
-      shell: bash
-      env:
-        NPM_TOKEN: ${{ inputs.token }}
     - name: Publish to NPM
       run: npm publish ${{ inputs.folder }} --tag ${{ inputs.tag }} --provenance
       shell: bash

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -33,7 +33,6 @@ jobs:
           tag: dev
           version: ${{ needs.create-dev-hash.outputs.dev-hash }}
           working-directory: './'
-          token: ${{ secrets.NPM_TOKEN }}
           createRelease: 'false'
 
   get-build:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,7 +1,7 @@
-name: 'Ionicons Dev Build'
+name: 'Dev Release'
 
 on:
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
   create-dev-hash:

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -24,6 +24,5 @@ jobs:
           tag: latest
           version: ${{ inputs.version }}
           working-directory: './'
-          token: ${{ secrets.NPM_TOKEN }}
           createRelease: true
           ghToken: ${{ secrets.IONITRON_TOKEN }}

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1,22 +1,12 @@
-name: 'Ionicons Production Release'
+name: 'Production Release'
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       version:
-        required: true
-        type: choice
-        description: Which version should be published?
-        options:
-          - patch
-          - minor
-          - major
-      tag:
-        required: true
-        type: choice
-        description: Which npm tag should this be published to?
-        options:
-          - latest
+        required: false
+        type: string
+        description: npm version (major, minor, or patch)
 
 jobs:
   release-ionicons:
@@ -31,7 +21,7 @@ jobs:
       - name: Publish to NPM
         uses: ./.github/workflows/actions/publish-npm
         with:
-          tag: ${{ inputs.tag }}
+          tag: latest
           version: ${{ inputs.version }}
           working-directory: './'
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -1,0 +1,33 @@
+name: 'Release Orchestrator'
+
+on:
+    workflow_dispatch:
+        inputs:
+            release-type:
+                description: 'Release type'
+                required: true
+                type: choice
+                options:
+                    - dev
+                    - production
+            version:
+                description: 'Version for production releases'
+                required: false
+                type: choice
+                options:
+                    - patch
+                    - minor
+                    - major
+
+jobs:
+    run-dev:
+        if: ${{ inputs.release-type == 'dev' }}
+        uses: ./.github/workflows/dev-release.yml
+        secrets: inherit
+
+    run-production:
+        if: ${{ inputs.release-type == 'production' }}
+        uses: ./.github/workflows/production-release.yml
+        secrets: inherit
+        with:
+            version: ${{ inputs.version }}

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -1,37 +1,37 @@
 name: 'Release Orchestrator'
 
 on:
-    workflow_dispatch:
-        inputs:
-            release-type:
-                description: 'Release type'
-                required: true
-                type: choice
-                options:
-                    - dev
-                    - production
-            version:
-                description: 'Version for production releases'
-                required: false
-                type: choice
-                options:
-                    - patch
-                    - minor
-                    - major
+  workflow_dispatch:
+    inputs:
+      release-type:
+        description: 'Release type'
+        required: true
+        type: choice
+        options:
+          - dev
+          - production
+      version:
+        description: 'Version for production releases'
+        required: false
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-    run-dev:
-        if: ${{ inputs.release-type == 'dev' }}
-        uses: ./.github/workflows/dev-release.yml
-        secrets: inherit
+  run-dev:
+    if: ${{ inputs.release-type == 'dev' }}
+    uses: ./.github/workflows/dev-release.yml
+    secrets: inherit
 
-    run-production:
-        if: ${{ inputs.release-type == 'production' }}
-        uses: ./.github/workflows/production-release.yml
-        secrets: inherit
-        with:
-            version: ${{ inputs.version }}
+  run-production:
+    if: ${{ inputs.release-type == 'production' }}
+    uses: ./.github/workflows/production-release.yml
+    secrets: inherit
+    with:
+      version: ${{ inputs.version }}

--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -19,6 +19,10 @@ on:
                     - minor
                     - major
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
     run-dev:
         if: ${{ inputs.release-type == 'dev' }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,4 +1,4 @@
-name: 'Ionicons Build'
+name: 'Validation'
 
 on:
   pull_request:


### PR DESCRIPTION
## Description
- Add a central orchestrator workflow
- Refactor release and build workflows to be called by the orchestrator
- Rename workflows to clarify what they do

## Change Type
- [ ] Fix
- [ ] Feature
- [X] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
NPM changed auth system, allowing only one workflow per project to submit builds. A central workflow must now kick off both production and dev workflows.